### PR TITLE
Fix setting the build action via FileNode automation

### DIFF
--- a/Dev10/Src/CSharp/FileNodeProperties.cs
+++ b/Dev10/Src/CSharp/FileNodeProperties.cs
@@ -81,7 +81,11 @@ namespace Microsoft.VisualStudio.Project
 
 			set
 			{
-				this.Node.ItemNode.ItemName = value.ToString();
+				KeyValuePair<string, prjBuildAction> pair = Node.ProjectManager.AvailableFileBuildActions.FirstOrDefault(i => i.Value == value);
+				if (!string.IsNullOrEmpty(pair.Key))
+					this.Node.ItemNode.ItemName = pair.Key;
+				else
+					this.Node.ItemNode.ItemName = value.ToString();
 			}
 		}
 


### PR DESCRIPTION
Regardless of the outcome of #62, the current `BuildAction` setter is not behaving as expected. This change maps `prjBuildAction` values back to their expected item names when they are set.