### PR TITLE
Allow the configuration or platform name to be an empty string

### DIFF
--- a/Dev10/Src/CSharp/ConfigProvider.cs
+++ b/Dev10/Src/CSharp/ConfigProvider.cs
@@ -158,10 +158,6 @@ namespace Microsoft.VisualStudio.Project
                 throw new ArgumentNullException("configName");
             if (platform == null)
                 throw new ArgumentNullException("platform");
-            if (string.IsNullOrEmpty(configName))
-                throw new ArgumentException("configName cannot be null or empty");
-            if (string.IsNullOrEmpty(platform))
-                throw new ArgumentException("platform cannot be null or empty");
 
             string key = string.Format("{0}|{1}", configName, platform);
 
@@ -181,10 +177,6 @@ namespace Microsoft.VisualStudio.Project
                 throw new ArgumentNullException("configName");
             if (platform == null)
                 throw new ArgumentNullException("platform");
-            if (string.IsNullOrEmpty(configName))
-                throw new ArgumentException("configName cannot be null or empty");
-            if (string.IsNullOrEmpty(platform))
-                throw new ArgumentException("platform cannot be null or empty");
 
             return new ProjectConfig(this._project, configName, platform);
         }

--- a/Dev10/Src/CSharp/ProjectNode.cs
+++ b/Dev10/Src/CSharp/ProjectNode.cs
@@ -4483,10 +4483,6 @@ namespace Microsoft.VisualStudio.Project
                 throw new ArgumentNullException("config");
             if (platform == null)
                 throw new ArgumentNullException("platform");
-            if (string.IsNullOrEmpty(config))
-                throw new ArgumentException("config cannot be null or empty");
-            if (string.IsNullOrEmpty(platform))
-                throw new ArgumentException("platform cannot be null or empty");
 
             // Can't ask for the active config until the project is opened, so do nothing in that scenario
             if (!projectOpened)


### PR DESCRIPTION
Several tests were failing due to this restriction, and I couldn't find any evidence in the new Common Project System that the affected methods limit the argument values in this way.